### PR TITLE
chore: swift 3 conversion wip

### DIFF
--- a/Tuner.xcodeproj/project.pbxproj
+++ b/Tuner.xcodeproj/project.pbxproj
@@ -165,6 +165,7 @@
 				TargetAttributes = {
 					22178DAD1C4D687E001B61AB = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -381,6 +382,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.timvanelsloo.Tuner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -397,6 +399,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.timvanelsloo.Tuner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Tuner/AppDelegate.swift
+++ b/Tuner/AppDelegate.swift
@@ -28,30 +28,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 

--- a/Tuner/Logic/Note.swift
+++ b/Tuner/Logic/Note.swift
@@ -32,33 +32,33 @@ enum Accidental: String {
 }
 
 enum Note: CustomStringConvertible {
-    case C(_: Accidental?)
-    case D(_: Accidental?)
-    case E(_: Accidental?)
-    case F(_: Accidental?)
-    case G(_: Accidental?)
-    case A(_: Accidental?)
-    case B(_: Accidental?)
+    case c(_: Accidental?)
+    case d(_: Accidental?)
+    case e(_: Accidental?)
+    case f(_: Accidental?)
+    case g(_: Accidental?)
+    case a(_: Accidental?)
+    case b(_: Accidental?)
 
     /**
      * This array contains all notes.
      */
     static let all: [Note] = [
-            C(nil),   C(.Sharp),
-            D(nil),
-            E(.Flat), E(nil),
-            F(nil),   F(.Sharp),
-            G(nil),
-            A(.Flat), A(nil),
-            B(.Flat), B(nil)
+            c(nil),   c(.Sharp),
+            d(nil),
+            e(.Flat), e(nil),
+            f(nil),   f(.Sharp),
+            g(nil),
+            a(.Flat), a(nil),
+            b(.Flat), b(nil)
      ]
 
     /**
      * This function returns the frequency of this note in the 4th octave.
      */
     var frequency: Double {
-        let index = Note.all.indexOf({ $0 == self   })! -
-                    Note.all.indexOf({ $0 == A(nil) })!
+        let index = Note.all.index(where: { $0 == self   })! -
+                    Note.all.index(where: { $0 == Note.a(nil) })!
 
         return 440 * pow(2, Double(index) / 12.0)
     }
@@ -73,13 +73,13 @@ enum Note: CustomStringConvertible {
         }
 
         switch self {
-            case let C(a): return concat("C", a)
-            case let D(a): return concat("D", a)
-            case let E(a): return concat("E", a)
-            case let F(a): return concat("F", a)
-            case let G(a): return concat("G", a)
-            case let A(a): return concat("A", a)
-            case let B(a): return concat("B", a)
+            case let .c(a): return concat("C", a)
+            case let .d(a): return concat("D", a)
+            case let .e(a): return concat("E", a)
+            case let .f(a): return concat("F", a)
+            case let .g(a): return concat("G", a)
+            case let .a(a): return concat("A", a)
+            case let .b(a): return concat("B", a)
         }
     }
 }

--- a/Tuner/Logic/Pitch.swift
+++ b/Tuner/Logic/Pitch.swift
@@ -39,7 +39,7 @@ class Pitch: CustomStringConvertible {
      */
     let frequency: Double
 
-    private init(note: Note, octave: Int) {
+    fileprivate init(note: Note, octave: Int) {
         self.note      = note
         self.octave    = octave
         self.frequency = note.frequency * pow(2, Double(octave) - 4)
@@ -54,12 +54,12 @@ class Pitch: CustomStringConvertible {
         Note.all.map { note -> Pitch in
             Pitch(note: note, octave: octave)
         }
-    }.flatten())
+    }.joined())
 
     /**
      * This function returns the nearest pitch to the given frequency in Hz.
      */
-    class func nearest(frequency: Double) -> Pitch {
+    class func nearest(_ frequency: Double) -> Pitch {
         /* Map all pitches to tuples of the pitch and the distance between the
          * frequency for that pitch and the given frequency. */
         var results = all.map { pitch -> (pitch: Pitch, distance: Double) in
@@ -67,7 +67,7 @@ class Pitch: CustomStringConvertible {
         }
 
         /* Sort array based on distance. */
-        results.sortInPlace { $0.distance < $1.distance }
+        results.sort { $0.distance < $1.distance }
 
         /* Return the first result (i.e. nearest pitch). */
         return results.first!.pitch
@@ -97,7 +97,7 @@ func ==(a: Pitch, b: Pitch) -> Bool {
  */
 func +(pitch: Pitch, offset: Int) -> Pitch {
     let all   = Pitch.all
-    let index = all.indexOf({ $0 == pitch })! + offset
+    let index = all.index(where: { $0 == pitch })! + offset
 
     return all[(index % all.count + all.count) % all.count]
 }

--- a/Tuner/Logic/Tuner.swift
+++ b/Tuner/Logic/Tuner.swift
@@ -30,7 +30,7 @@ protocol TunerDelegate {
      * distance is between the actual tracked frequency and the nearest note.
      * Finally, the amplitude is the volume (note: of all frequencies).
      */
-    func tunerDidMeasurePitch(pitch: Pitch, withDistance distance: Double,
+    func tunerDidMeasurePitch(_ pitch: Pitch, withDistance distance: Double,
                               amplitude: Double)
 }
 
@@ -38,21 +38,21 @@ class Tuner: NSObject {
     var delegate: TunerDelegate?
 
     /* Private instance variables. */
-    private var timer:      NSTimer?
-    private let microphone: AKMicrophone
-    private let analyzer:   AKAudioAnalyzer
+    fileprivate var timer:      Timer?
+    fileprivate let microphone: AKMicrophone
+    fileprivate let analyzer:   AKAudioAnalyzer
 
     override init() {
         /* Start application-wide microphone recording. */
-        AKManager.sharedManager().enableAudioInput()
+        AKManager.shared().enableAudioInput()
 
         /* Add the built-in microphone. */
         microphone = AKMicrophone()
-        AKOrchestra.addInstrument(microphone)
+        AKOrchestra.add(microphone)
 
         /* Add an analyzer and store it in an instance variable. */
         analyzer = AKAudioAnalyzer(input: microphone.output)
-        AKOrchestra.addInstrument(analyzer)
+        AKOrchestra.add(analyzer)
     }
 
     func startMonitoring() {
@@ -61,8 +61,8 @@ class Tuner: NSObject {
         microphone.play()
 
         /* Initialize and schedule a new run loop timer. */
-        timer = NSTimer.scheduledTimerWithTimeInterval(0.1, target: self,
-                                                       selector: "tick",
+        timer = Timer.scheduledTimer(timeInterval: 0.1, target: self,
+                                                       selector: #selector(Tuner.tick),
                                                        userInfo: nil,
                                                        repeats: true)
     }

--- a/Tuner/UI/DisplayView.swift
+++ b/Tuner/UI/DisplayView.swift
@@ -23,8 +23,8 @@
 import UIKit
 
 class DisplayView: UIView {
-    private let gradientLayer = CAGradientLayer()
-    private let plotView =      PlotView()
+    fileprivate let gradientLayer = CAGradientLayer()
+    fileprivate let plotView =      PlotView()
     
     var amplitude: Double = 0.0 {
         didSet {
@@ -41,15 +41,15 @@ class DisplayView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        plotView.autoresizingMask = [ .FlexibleWidth, .FlexibleHeight ]
+        plotView.autoresizingMask = [ .flexibleWidth, .flexibleHeight ]
         plotView.frame = self.bounds
         self.addSubview(plotView)
         
-        gradientLayer.colors     = [ UIColor.clearColor().CGColor,
-                                     UIColor.blackColor().CGColor,
-                                     UIColor.clearColor().CGColor ]
-        gradientLayer.startPoint = CGPointZero
-        gradientLayer.endPoint   = CGPointMake(1.0, 0.0)
+        gradientLayer.colors     = [ UIColor.clear.cgColor,
+                                     UIColor.black.cgColor,
+                                     UIColor.clear.cgColor ]
+        gradientLayer.startPoint = CGPoint.zero
+        gradientLayer.endPoint   = CGPoint(x: 1.0, y: 0.0)
         self.layer.mask = gradientLayer
     }
     
@@ -57,11 +57,11 @@ class DisplayView: UIView {
         super.init(coder: aDecoder)
     }
     
-    override func willMoveToSuperview(newSuperview: UIView?) {
-        super.willMoveToSuperview(newSuperview)
+    override func willMove(toSuperview newSuperview: UIView?) {
+        super.willMove(toSuperview: newSuperview)
         
         let maskLayer = CAShapeLayer()
-        maskLayer.path      = UIBezierPath(ovalInRect: self.bounds).CGPath
+        maskLayer.path      = UIBezierPath(ovalIn: self.bounds).cgPath
         gradientLayer.frame = self.bounds
         gradientLayer.mask  = maskLayer
     }

--- a/Tuner/UI/KnobView.swift
+++ b/Tuner/UI/KnobView.swift
@@ -23,21 +23,21 @@
 import UIKit
 
 class KnobView: UIView {
-    private let thinLayer   = CAShapeLayer()
-    private let thickLayer  = CAShapeLayer()
-    private let arrowLayer  = CAShapeLayer()
-    private let stableLayer = CALayer()
-    private let turnLayer   = CALayer()
-    private let labels      = (0 ... 4).map { _ in CATextLayer() }
-    private var timer: NSTimer?
+    fileprivate let thinLayer   = CAShapeLayer()
+    fileprivate let thickLayer  = CAShapeLayer()
+    fileprivate let arrowLayer  = CAShapeLayer()
+    fileprivate let stableLayer = CALayer()
+    fileprivate let turnLayer   = CALayer()
+    fileprivate let labels      = (0 ... 4).map { _ in CATextLayer() }
+    fileprivate var timer: Timer?
     
     var distance: Double = 0 {
         didSet {
             let angle = CGFloat(distance * M_PI)
-            turnLayer.setAffineTransform(CGAffineTransformMakeRotation(-angle))
+            turnLayer.setAffineTransform(CGAffineTransform(rotationAngle: -angle))
             
             for label in labels {
-                label.setAffineTransform(CGAffineTransformMakeRotation(angle))
+                label.setAffineTransform(CGAffineTransform(rotationAngle: angle))
             }
         }
     }
@@ -46,14 +46,14 @@ class KnobView: UIView {
         didSet {
             if pitch != nil {
                 updated = 1
-                UIView.animateWithDuration(0.2, delay: 0.0,
+                UIView.animate(withDuration: 0.2, delay: 0.0,
                         usingSpringWithDamping: 1.0,
                         initialSpringVelocity: 0.0,
-                        options: .CurveLinear, animations: {
+                        options: .curveLinear, animations: {
                     self.alpha = 1.0
                 }, completion: nil)
 
-                for (i, label) in labels.enumerate() {
+                for (i, label) in labels.enumerated() {
                     label.string = (pitch! + i - 2).description
                 }
             }else {
@@ -72,15 +72,15 @@ class KnobView: UIView {
         turnLayer.frame            = self.bounds
         self.layer.addSublayer(turnLayer)
 
-        let frame                  = CGRectInset(self.bounds, 8.0, 8.0)
-        let path                   = UIBezierPath(ovalInRect: frame).CGPath
-        let strokeColor            = UIColor.whiteColor().CGColor
+        let frame                  = self.bounds.insetBy(dx: 8.0, dy: 8.0)
+        let path                   = UIBezierPath(ovalIn: frame).cgPath
+        let strokeColor            = UIColor.white.cgColor
 
         thinLayer.frame            = frame
         thinLayer.path             = path
         thinLayer.strokeColor      = strokeColor
         thinLayer.lineWidth        = 16.0
-        thinLayer.fillColor        = UIColor.clearColor().CGColor
+        thinLayer.fillColor        = UIColor.clear.cgColor
         thinLayer.lineDashPattern  = [ 0.5, 5.5 ]
         thinLayer.lineDashPhase    = 0.25
         turnLayer.addSublayer(thinLayer)
@@ -89,37 +89,37 @@ class KnobView: UIView {
         thickLayer.path            = path
         thickLayer.strokeColor     = strokeColor
         thickLayer.lineWidth       = 16.0
-        thickLayer.fillColor       = UIColor.clearColor().CGColor
+        thickLayer.fillColor       = UIColor.clear.cgColor
         thickLayer.lineDashPattern = [ 1.5, 58.5 ]
         thickLayer.lineDashPhase   = 0.75
         turnLayer.addSublayer(thickLayer)
         
         let arrowPath = UIBezierPath()
-        arrowPath.moveToPoint(CGPointMake(8.0, 0.0))      /* Top */
-        arrowPath.addLineToPoint(CGPointMake(16.0, 13.0)) /* Right */
-        arrowPath.addLineToPoint(CGPointMake(0.0,  13.0)) /* Left */
-        arrowPath.addLineToPoint(CGPointMake(8.0,  0.0))  /* Back to top */
-        arrowPath.closePath()
+        arrowPath.move(to: CGPoint(x: 8.0, y: 0.0))      /* Top */
+        arrowPath.addLine(to: CGPoint(x: 16.0, y: 13.0)) /* Right */
+        arrowPath.addLine(to: CGPoint(x: 0.0,  y: 13.0)) /* Left */
+        arrowPath.addLine(to: CGPoint(x: 8.0,  y: 0.0))  /* Back to top */
+        arrowPath.close()
         
-        arrowLayer.frame           = CGRectMake(0.0, 0.0, 16.0, 13.0)
-        arrowLayer.path            = arrowPath.CGPath
-        arrowLayer.fillColor       = UIColor.redColor().CGColor
+        arrowLayer.frame           = CGRect(x: 0.0, y: 0.0, width: 16.0, height: 13.0)
+        arrowLayer.path            = arrowPath.cgPath
+        arrowLayer.fillColor       = UIColor.red.cgColor
         turnLayer.addSublayer(arrowLayer)
         
-        stableLayer.frame           = CGRectMake(0.0, -56.0, 5.0, 72.0)
+        stableLayer.frame           = CGRect(x: 0.0, y: -56.0, width: 5.0, height: 72.0)
         stableLayer.backgroundColor = thickLayer.strokeColor
         self.layer.addSublayer(stableLayer)
         
-        for (i, label) in labels.enumerate() {
-            label.frame               = CGRectMake(0.0, 0.0, 80.0, 40.0)
+        for (i, label) in labels.enumerated() {
+            label.frame               = CGRect(x: 0.0, y: 0.0, width: 80.0, height: 40.0)
             label.alignmentMode       = kCAAlignmentCenter
-            label.contentsScale       = UIScreen.mainScreen().scale
-            label.foregroundColor     = UIColor.whiteColor().CGColor
-            label.font                = UIFont.systemFontOfSize(17, weight: UIFontWeightUltraLight)
+            label.contentsScale       = UIScreen.main.scale
+            label.foregroundColor     = UIColor.white.cgColor
+            label.font                = UIFont.systemFont(ofSize: 17, weight: UIFontWeightUltraLight)
             label.fontSize            = 17.0
             
             if i == 2 {
-                label.font            = UIFont.systemFontOfSize(36, weight: UIFontWeightUltraLight)
+                label.font            = UIFont.systemFont(ofSize: 36, weight: UIFontWeightUltraLight)
                 label.fontSize       *= 2.0
             }
             
@@ -134,16 +134,16 @@ class KnobView: UIView {
     override var frame: CGRect {
         didSet {
             turnLayer.frame       = self.bounds
-            turnLayer.anchorPoint = CGPointMake(0.5, 0.5)
+            turnLayer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
 
-            let frame         = CGRectInset(self.bounds, 8.0, 8.0)
-            let path          = UIBezierPath(ovalInRect: thinLayer.bounds)
+            let frame         = self.bounds.insetBy(dx: 8.0, dy: 8.0)
+            let path          = UIBezierPath(ovalIn: thinLayer.bounds)
             
             thinLayer.frame   = frame
-            thinLayer.path    = path.CGPath
+            thinLayer.path    = path.cgPath
             
             thickLayer.frame  = frame
-            thickLayer.path   = path.CGPath
+            thickLayer.path   = path.cgPath
             
             arrowLayer.frame  = CGRect(
                 origin: CGPoint(
@@ -167,12 +167,12 @@ class KnobView: UIView {
             )
             
             
-            for (i, label) in labels.enumerate() {
+            for (i, label) in labels.enumerated() {
                 let offset: CGFloat = 30.0 + (i == 2 ? 50.0 : 0.0)
                 
-                let half = CGSizeMake(self.bounds.width / 2.0 + offset, self.bounds.height / 2.0 + offset)
-                let center = CGPointMake(half.width - half.width * sin(CGFloat(i - 5) / 6 * 2 * 3.14) - offset,
-                                         half.height + half.height * cos(CGFloat(i - 5) / 6 * 2 * 3.14) - offset)
+                let half = CGSize(width: self.bounds.width / 2.0 + offset, height: self.bounds.height / 2.0 + offset)
+                let center = CGPoint(x: half.width - half.width * sin(CGFloat(i - 5) / 6 * 2 * 3.14) - offset,
+                                         y: half.height + half.height * cos(CGFloat(i - 5) / 6 * 2 * 3.14) - offset)
                 label.frame.origin.x = center.x - label.frame.size.width / 2.0
                 label.frame.origin.y = center.y - label.frame.size.height / 2.0
             }
@@ -185,23 +185,23 @@ class KnobView: UIView {
         if self.window == nil {
             self.timer?.invalidate()
         }else {
-            NSTimer.scheduledTimerWithTimeInterval(1.0, target: self,
-                                                   selector: "tick",
+            Timer.scheduledTimer(timeInterval: 1.0, target: self,
+                                                   selector: #selector(KnobView.tick),
                                                    userInfo: nil, repeats: true)
         }
     }
 
-    private var updated = 0
+    fileprivate var updated = 0
 
     func tick() {
         if updated == 0 {
             self.distance = 0.0
             self.pitch    = nil
 
-            UIView.animateWithDuration(1.0, delay: 0.0,
+            UIView.animate(withDuration: 1.0, delay: 0.0,
                                        usingSpringWithDamping: 1.0,
                                        initialSpringVelocity: 0.0,
-                                       options: .CurveLinear, animations: {
+                                       options: .curveLinear, animations: {
                 self.alpha = 0.5
             }, completion: nil)
         }else {

--- a/Tuner/UI/ViewController.swift
+++ b/Tuner/UI/ViewController.swift
@@ -26,13 +26,13 @@ import UIKit
 class ViewController: UIViewController, TunerDelegate {
     let tuner       = Tuner()
     let displayView = DisplayView()
-    let knobView    = KnobView(frame: CGRectMake(0, 0, 245, 245))
+    let knobView    = KnobView(frame: CGRect(x: 0, y: 0, width: 245, height: 245))
     
     override func viewDidLoad() {
         super.viewDidLoad()
 
         /* Update the background color. */
-        self.view.backgroundColor = .blackColor()
+        self.view.backgroundColor = UIColor.black;
 
         /* Setup the display view. */
         displayView.frame = CGRect(
@@ -55,11 +55,11 @@ class ViewController: UIViewController, TunerDelegate {
         tuner.startMonitoring()
     }
     
-    override func preferredStatusBarStyle() -> UIStatusBarStyle {
-        return .LightContent
+    override var preferredStatusBarStyle : UIStatusBarStyle {
+        return .lightContent
     }
 
-    func tunerDidMeasurePitch(pitch: Pitch, withDistance distance: Double,
+    func tunerDidMeasurePitch(_ pitch: Pitch, withDistance distance: Double,
                               amplitude: Double) {
         /* Scale the amplitude to make it look more dramatic. */
         displayView.amplitude = min(1.0, amplitude * 25.0)


### PR DESCRIPTION
@elslooo This is an attempt to convert to latest Swift 3 and other XCode 8 compatibilities.

It is close but running into this at moment when you run it:

```
fatal error: storeBytes to misaligned raw pointer
```

Related to some of the conversion trials here:
https://github.com/NathanWalker/guitar-tuner/blob/5ce8cd5385dbbd4352ef919985fae25dcdfc162b/Tuner/UI/PlotView.swift#L42-L87

You may know better how to convert that section?
I've been using this migration guide:
https://swift.org/migration-guide/se-0107-migrate.html
Also this appears to show the closest example of what that section was intending to do:
https://github.com/apple/swift-evolution/blob/master/proposals/0107-unsaferawpointer.md
^^ In there, search in browser for "UnsafeMutableRawPointer.storeBytes" and you'll see a sample using the new changes.

Also, I'm interested in doing a [NativeScript](https://www.nativescript.org/) conversion of this project for a tutorial if we can get this running in the new syntax and you would be alright with that?
